### PR TITLE
Add 'Not Found' status to PendingStatusVerifyCreated

### DIFF
--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -16,7 +16,7 @@ const (
 
 var (
 	PendingStatusCRUD          = []string{http.StatusText(http.StatusTooManyRequests), http.StatusText(http.StatusFailedDependency)}
-	PendingStatusVerifyCreated = []string{http.StatusText(http.StatusFailedDependency), http.StatusText(http.StatusTooManyRequests)}
+	PendingStatusVerifyCreated = []string{http.StatusText(http.StatusFailedDependency), http.StatusText(http.StatusTooManyRequests), http.StatusText(http.StatusNotFound)}
 	PendingStatusVerifyDeleted = []string{http.StatusText(200), http.StatusText(http.StatusTooManyRequests)}
 
 	TargetStatusResourceChange  = []string{http.StatusText(http.StatusAccepted)}


### PR DESCRIPTION
During polling waiting for an index to be created, the API can return a Not Found status, and this isn't handled during creation as a retry.  This results in this message:

Error: Error waiting for index (test-index) to be created: unexpected state 'Not Found', wanted target 'OK'. last error: {"code":"404-index-not-found","message":"test-index index not found. Please refer to https://docs.splunk.com/Documentation/SplunkCloud/latest/Config/ACSerrormessages for general troubleshooting tips."}

This small patch just adds the NotFound status to the Pending list so the polling continues. 