### PR TITLE
Fix index max_data_size_mb reset to zero

### DIFF
--- a/internal/indexes/index_resource.go
+++ b/internal/indexes/index_resource.go
@@ -245,6 +245,10 @@ func parseIndexRequest(d *schema.ResourceData) *v2.IndexInfo {
 	if maxDataSizeMB, ok := d.GetOk("max_data_size_mb"); ok {
 		parsedData := int64(maxDataSizeMB.(float64))
 		indexRequest.MaxDataSizeMB = &parsedData
+	} else if d.HasChange("max_data_size_mb") {
+		_, newVal := d.GetChange("max_data_size_mb")
+		parsedData := int64(newVal.(float64))
+		indexRequest.MaxDataSizeMB = &parsedData
 	}
 
 	if searchableDays, ok := d.GetOk("searchable_days"); ok {

--- a/internal/indexes/index_resource_test.go
+++ b/internal/indexes/index_resource_test.go
@@ -94,6 +94,29 @@ func TestAcc_SplunkCloudIndex_DatasizeField(t *testing.T) {
 	})
 }
 
+func TestAcc_SplunkCloudIndex_DatasizeFieldResetToZero(t *testing.T) {
+	// Test creating an Index resource with max_data_size_mb set and then resetting it to 0.
+	datasizeFieldResource := resource.UniqueId()
+
+	datasizeFieldTest := []resource.TestStep{
+		{
+			Config: testAccInstanceConfigMaxDataSize(datasizeFieldResource, "1000"),
+			Check:  resource.TestCheckResourceAttr(resourcePrefix(datasizeFieldResource), "max_data_size_mb", "1000"),
+		},
+		{
+			Config: testAccInstanceConfigMaxDataSize(datasizeFieldResource, "0"),
+			Check:  resource.TestCheckResourceAttr(resourcePrefix(datasizeFieldResource), "max_data_size_mb", "0"),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckIndexDestroy,
+		Steps:             datasizeFieldTest,
+	})
+}
+
 func TestAcc_SplunkCloudIndex_ArchivalField(t *testing.T) {
 	// Test creating an Index resource and then updating splunk_archival_retention_days field
 	archivalFieldResource := resource.UniqueId()
@@ -147,6 +170,10 @@ func TestAcc_SplunkCloudIndex_ArchivalField(t *testing.T) {
 
 func testAccInstanceConfigBasic(name string) string {
 	return fmt.Sprintf("resource \"scp_indexes\" %[1]q {name = %[1]q}", name)
+}
+
+func testAccInstanceConfigMaxDataSize(name, maxDataSizeMb string) string {
+	return fmt.Sprintf("resource \"scp_indexes\" %[1]q {\nname = %[1]q \nmax_data_size_mb = %[2]q \n}", name, maxDataSizeMb)
 }
 
 func testAccInstanceConfigAllFields(name, searchableDays, maxDataSizeMb, retentionDays, datatype string) string {


### PR DESCRIPTION
When setting an index back to 0 (Unlimited) from an existing value it doesn't update. Stays at the old value.